### PR TITLE
Don't generate sourcemaps if user disables them

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,16 @@ module.exports = function (source) {
         return accumulator;
     }, {});
 
-    options.sourceMap = true;
+    options.sourceMap = this.sourceMap;
     options.filename = loaderUtils.getRemainingRequest(this);
 
     result = to5.transform(source, options);
     code = result.code;
+
     map = result.map;
-    map.sourcesContent = [source];
+    if (map) {
+        map.sourcesContent = [source];
+    }
 
     this.callback(null, code, map);
 


### PR DESCRIPTION
Currently, source maps are always generated, even if Webpack doesn't use them.

However Webpack provides [`this.sourceMap`](http://webpack.github.io/docs/loaders.html#sourcemap) to loaders.
This flag will only be `true` if user enabled source maps in their Webpack config.